### PR TITLE
Update supervisely to 6.74.18 and bump image to 1.0.48

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,8 +1,8 @@
 # git+https://github.com/supervisely/supervisely.git@some-test-branch
 
-supervisely[training]==6.74.16
-supervisely[tracking]==6.74.16
-supervisely[model-benchmark]==6.74.16
+supervisely[training]==6.74.18
+supervisely[tracking]==6.74.18
+supervisely[model-benchmark]==6.74.18
 
 setuptools==69.5.1
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN pip install --no-cache-dir setuptools==69.5.1 tensorboard imgaug==0.4.0 deco
 # TEMP: SDK from the resume-artifacts-upload branch. Revert to the pinned release before merge.
 # RELEASE_VERSION is required: setup.py get_version() otherwise queries git tags / the GitHub API,
 # which fails inside pip shallow clone. SDK_REF also busts the docker layer cache.
-ARG SDK_REF=ad51004c8bcb215f833732394ff8c61f483c6883
+ARG SDK_REF=b84d3d151c442a3d84d30486c209d72c819cd92e
 RUN RELEASE_VERSION=6.74.16 pip install --no-cache-dir \
     "supervisely[training,tracking,model-benchmark] @ git+https://github.com/supervisely/supervisely.git@${SDK_REF}"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,11 +56,8 @@ RUN pip install --no-cache-dir tensorrt-cu12==10.9.0.34
 RUN pip install --no-cache-dir setuptools==69.5.1 tensorboard imgaug==0.4.0 decord
 
 
-# TEMP: SDK from the resume-artifacts-upload branch. Revert to the pinned release before merge.
-# RELEASE_VERSION is required: setup.py get_version() otherwise queries git tags / the GitHub API,
-# which fails inside pip shallow clone. SDK_REF also busts the docker layer cache.
-ARG SDK_REF=b84d3d151c442a3d84d30486c209d72c819cd92e
-RUN RELEASE_VERSION=6.74.16 pip install --no-cache-dir \
-    "supervisely[training,tracking,model-benchmark] @ git+https://github.com/supervisely/supervisely.git@${SDK_REF}"
+RUN pip install --no-cache-dir supervisely[training]==6.74.18
+RUN pip install --no-cache-dir supervisely[tracking]==6.74.18
+RUN pip install --no-cache-dir supervisely[model-benchmark]==6.74.18
 
-LABEL python_sdk_version="6.74.16"
+LABEL python_sdk_version="6.74.18"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN pip install --no-cache-dir setuptools==69.5.1 tensorboard imgaug==0.4.0 deco
 # TEMP: SDK from the resume-artifacts-upload branch. Revert to the pinned release before merge.
 # RELEASE_VERSION is required: setup.py get_version() otherwise queries git tags / the GitHub API,
 # which fails inside pip shallow clone. SDK_REF also busts the docker layer cache.
-ARG SDK_REF=975ab6e14217f59a9b26f96a4fc60df3f1e53fa5
+ARG SDK_REF=fb0ee7433e43f39d899ab7e503b7e08cac03d34c
 RUN RELEASE_VERSION=6.74.16 pip install --no-cache-dir \
     "supervisely[training,tracking,model-benchmark] @ git+https://github.com/supervisely/supervisely.git@${SDK_REF}"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN pip install --no-cache-dir setuptools==69.5.1 tensorboard imgaug==0.4.0 deco
 # TEMP: SDK from the resume-artifacts-upload branch. Revert to the pinned release before merge.
 # RELEASE_VERSION is required: setup.py get_version() otherwise queries git tags / the GitHub API,
 # which fails inside pip shallow clone. SDK_REF also busts the docker layer cache.
-ARG SDK_REF=3ffb7eee74636b57e8a05cd263ff57f74c80e0be
+ARG SDK_REF=320664e32b7aeece6413f0f7806d320eaae9a9dc
 RUN RELEASE_VERSION=6.74.16 pip install --no-cache-dir \
     "supervisely[training,tracking,model-benchmark] @ git+https://github.com/supervisely/supervisely.git@${SDK_REF}"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN pip install --no-cache-dir setuptools==69.5.1 tensorboard imgaug==0.4.0 deco
 # TEMP: SDK from the resume-artifacts-upload branch. Revert to the pinned release before merge.
 # RELEASE_VERSION is required: setup.py get_version() otherwise queries git tags / the GitHub API,
 # which fails inside pip shallow clone. SDK_REF also busts the docker layer cache.
-ARG SDK_REF=b98d2a25d6afa1e4bc9dafcc3cd097b1d0e05164
+ARG SDK_REF=561597816fdf52a6e33dca1bb061a17eb1cde5c7
 RUN RELEASE_VERSION=6.74.16 pip install --no-cache-dir \
     "supervisely[training,tracking,model-benchmark] @ git+https://github.com/supervisely/supervisely.git@${SDK_REF}"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN pip install --no-cache-dir setuptools==69.5.1 tensorboard imgaug==0.4.0 deco
 # TEMP: SDK from the resume-artifacts-upload branch. Revert to the pinned release before merge.
 # RELEASE_VERSION is required: setup.py get_version() otherwise queries git tags / the GitHub API,
 # which fails inside pip shallow clone. SDK_REF also busts the docker layer cache.
-ARG SDK_REF=320664e32b7aeece6413f0f7806d320eaae9a9dc
+ARG SDK_REF=b98d2a25d6afa1e4bc9dafcc3cd097b1d0e05164
 RUN RELEASE_VERSION=6.74.16 pip install --no-cache-dir \
     "supervisely[training,tracking,model-benchmark] @ git+https://github.com/supervisely/supervisely.git@${SDK_REF}"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN pip install --no-cache-dir setuptools==69.5.1 tensorboard imgaug==0.4.0 deco
 # TEMP: SDK from the resume-artifacts-upload branch. Revert to the pinned release before merge.
 # RELEASE_VERSION is required: setup.py get_version() otherwise queries git tags / the GitHub API,
 # which fails inside pip shallow clone. SDK_REF also busts the docker layer cache.
-ARG SDK_REF=fb0ee7433e43f39d899ab7e503b7e08cac03d34c
+ARG SDK_REF=3ffb7eee74636b57e8a05cd263ff57f74c80e0be
 RUN RELEASE_VERSION=6.74.16 pip install --no-cache-dir \
     "supervisely[training,tracking,model-benchmark] @ git+https://github.com/supervisely/supervisely.git@${SDK_REF}"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN pip install --no-cache-dir setuptools==69.5.1 tensorboard imgaug==0.4.0 deco
 # TEMP: SDK from the resume-artifacts-upload branch. Revert to the pinned release before merge.
 # RELEASE_VERSION is required: setup.py get_version() otherwise queries git tags / the GitHub API,
 # which fails inside pip shallow clone. SDK_REF also busts the docker layer cache.
-ARG SDK_REF=561597816fdf52a6e33dca1bb061a17eb1cde5c7
+ARG SDK_REF=ad51004c8bcb215f833732394ff8c61f483c6883
 RUN RELEASE_VERSION=6.74.16 pip install --no-cache-dir \
     "supervisely[training,tracking,model-benchmark] @ git+https://github.com/supervisely/supervisely.git@${SDK_REF}"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,8 +56,11 @@ RUN pip install --no-cache-dir tensorrt-cu12==10.9.0.34
 RUN pip install --no-cache-dir setuptools==69.5.1 tensorboard imgaug==0.4.0 decord
 
 
-RUN pip install --no-cache-dir supervisely[training]==6.74.16
-RUN pip install --no-cache-dir supervisely[tracking]==6.74.16
-RUN pip install --no-cache-dir supervisely[model-benchmark]==6.74.16
+# TEMP: SDK from the resume-artifacts-upload branch. Revert to the pinned release before merge.
+# RELEASE_VERSION is required: setup.py get_version() otherwise queries git tags / the GitHub API,
+# which fails inside pip shallow clone. SDK_REF also busts the docker layer cache.
+ARG SDK_REF=975ab6e14217f59a9b26f96a4fc60df3f1e53fa5
+RUN RELEASE_VERSION=6.74.16 pip install --no-cache-dir \
+    "supervisely[training,tracking,model-benchmark] @ git+https://github.com/supervisely/supervisely.git@${SDK_REF}"
 
 LABEL python_sdk_version="6.74.16"

--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -1,2 +1,2 @@
-docker build -t supervisely/rt-detrv2:1.0.47 . && \
-docker push supervisely/rt-detrv2:1.0.47
+docker build -t supervisely/rt-detrv2:1.0.47-resume-test . && \
+docker push supervisely/rt-detrv2:1.0.47-resume-test

--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -1,2 +1,2 @@
-docker build -t supervisely/rt-detrv2:1.0.47-resume-test . && \
-docker push supervisely/rt-detrv2:1.0.47-resume-test
+docker build -t supervisely/rt-detrv2:1.0.48 . && \
+docker push supervisely/rt-detrv2:1.0.48

--- a/supervisely_integration/serve/config.json
+++ b/supervisely_integration/serve/config.json
@@ -24,7 +24,7 @@
         "sly_video_tracking_by_detection"
     ],
     "community_agent": false,
-    "docker_image": "supervisely/rt-detrv2:1.0.47",
+    "docker_image": "supervisely/rt-detrv2:1.0.48",
     "cuda_version": 12.8,
     "task_location": "application_sessions",
     "license": {

--- a/supervisely_integration/train/config.json
+++ b/supervisely_integration/train/config.json
@@ -16,7 +16,7 @@
     "icon_cover": true,
     "poster": "https://github.com/user-attachments/assets/b4554de5-3d2c-4b4f-aba9-95864cb05289",
     "description": "Train RT-DETRv2 model on your data",
-    "docker_image": "supervisely/rt-detrv2:1.0.47-resume-test",
+    "docker_image": "supervisely/rt-detrv2:1.0.48",
     "cuda_version": 12.8,
     "instance_version": "6.17.8",
     "task_location": "workspace_tasks",

--- a/supervisely_integration/train/config.json
+++ b/supervisely_integration/train/config.json
@@ -16,7 +16,7 @@
     "icon_cover": true,
     "poster": "https://github.com/user-attachments/assets/b4554de5-3d2c-4b4f-aba9-95864cb05289",
     "description": "Train RT-DETRv2 model on your data",
-    "docker_image": "supervisely/rt-detrv2:1.0.47",
+    "docker_image": "supervisely/rt-detrv2:1.0.47-resume-test",
     "cuda_version": 12.8,
     "instance_version": "6.17.8",
     "task_location": "workspace_tasks",


### PR DESCRIPTION
Picks up the resume-upload fix released in SDK 6.74.18 (supervisely/supervisely#1776).